### PR TITLE
PR - Multiple Troubleshooting Steps

### DIFF
--- a/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/AgLogonScript.ps1
@@ -233,7 +233,6 @@ if ($scenario -eq "contoso_supermarket") {
 }
 
 if ($scenario -eq "contoso_motors") {
-    Update-AzureIoTOpsExtension
     Deploy-AIO-M3
     Deploy-MotorsConfigs
     $mqttIpArray=Set-MQTTIpAddress

--- a/azure_jumpstart_ag/artifacts/PowerShell/Modules/contoso_hypermarket.psm1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Modules/contoso_hypermarket.psm1
@@ -204,6 +204,7 @@ function Deploy-AIO-M3 {
                 --sa-resource-id $(az storage account show --name $aioStorageAccountName --resource-group $resourceGroup -o tsv --query id) `
                 --query id -o tsv)
 
+        Write-Host "[$(Get-Date -Format t)] INFO: The aio storage account name is: $aioStorageAccountName" -ForegroundColor DarkGray
         Write-Host "[$(Get-Date -Format t)] INFO: the schemaId is '$schemaId' - verify this" -ForegroundColor DarkGray
 
         $customLocationName = $arcClusterName.toLower() + "-cl"

--- a/azure_jumpstart_ag/artifacts/PowerShell/Modules/contoso_hypermarket.psm1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Modules/contoso_hypermarket.psm1
@@ -204,6 +204,8 @@ function Deploy-AIO-M3 {
                 --sa-resource-id $(az storage account show --name $aioStorageAccountName --resource-group $resourceGroup -o tsv --query id) `
                 --query id -o tsv)
 
+        Write-Host "[$(Get-Date -Format t)] INFO: the schemaId is '$schemaId' - verify this" -ForegroundColor DarkGray
+
         $customLocationName = $arcClusterName.toLower() + "-cl"
 
         # Initialize the Azure IoT Operations instance on the Arc-enabled cluster

--- a/azure_jumpstart_ag/artifacts/PowerShell/Modules/contoso_hypermarket.psm1
+++ b/azure_jumpstart_ag/artifacts/PowerShell/Modules/contoso_hypermarket.psm1
@@ -199,9 +199,9 @@ function Deploy-AIO-M3 {
         Write-Host "`n"
         $schemaName = "${clusterName}-$($Env:namingGuid)-schema"
         $schemaId = $(az iot ops schema registry create --name $schemaName `
-                --resource-group $resourceGroup `
+                --resource-group $Env:resourceGroup `
                 --registry-namespace "$clusterName-$($Env:namingGuid)-namespace" `
-                --sa-resource-id $(az storage account show --name $aioStorageAccountName --resource-group $resourceGroup -o tsv --query id) `
+                --sa-resource-id $(az storage account show --name $Env:aioStorageAccountName --resource-group $Env:resourceGroup -o tsv --query id) `
                 --query id -o tsv)
 
         Write-Host "[$(Get-Date -Format t)] INFO: The aio storage account name is: $aioStorageAccountName" -ForegroundColor DarkGray
@@ -223,8 +223,8 @@ function Deploy-AIO-M3 {
                 Write-Host "[$(Get-Date -Format t)] Error: An error occured while deploying AIO on the cluster...Retrying" -ForegroundColor DarkRed
                 Write-Host "`n"
                 az iot ops init --cluster $arcClusterName.toLower() `
-                    --resource-group $resourceGroup `
-                    --subscription $subscriptionId `
+                    --resource-group $Env:resourceGroup `
+                    --subscription $Env:subscriptionId `
                     --only-show-errors
                 $retryCount++
             }
@@ -241,10 +241,10 @@ function Deploy-AIO-M3 {
         do {
             az iot ops create --name $arcClusterName.toLower() `
                 --cluster $arcClusterName.toLower() `
-                --resource-group $resourceGroup `
-                --subscription $subscriptionId `
-                --custom-location $customLocationName `
-                --sr-resource-id $schemaId `
+                --resource-group $Env:resourceGroup `
+                --subscription $Env:subscriptionId `
+                --custom-location customLocationName `
+                --sr-resource-id schemaId `
                 --enable-rsync true `
                 --add-insecure-listener true `
                 --only-show-errors

--- a/azure_jumpstart_ag/artifacts/kubernetes/K3s/installK3s.sh
+++ b/azure_jumpstart_ag/artifacts/kubernetes/K3s/installK3s.sh
@@ -18,6 +18,7 @@ echo $storageContainerName:$8 | awk '{print substr($1,2); }' >> vars.sh
 echo $k3sControlPlane:$9 | awk '{print substr($1,2); }' >> vars.sh
 echo $resourceGroup:$10| awk '{print substr($1,2); }' >> vars.sh
 echo $deployGPUNodes:$11| awk '{print substr($1,2); }' >> vars.sh
+echo $scenario:$12| awk '{print substr($1,2); }' >> vars.sh
 
 sed -i '2s/^/export adminUsername=/' vars.sh
 sed -i '3s/^/export subscriptionId=/' vars.sh
@@ -317,5 +318,14 @@ exec 1>&3 2>&4 # Further commands will now output to the original stdout and std
 log="/home/$adminUsername/jumpstart_logs/installK3s-$vmName.log"
 storageContainerNameLower=$(echo $storageContainerName | tr '[:upper:]' '[:lower:]')
 azcopy cp $log "https://$stagingStorageAccountName.blob.core.windows.net/$storageContainerNameLower/installK3s-$vmName.log" --check-length=false >/dev/null 2>&1
+
+# Add the if statement to check the scenario and run the curl command if scenario is contoso-motors
+if [[ "$scenario" == "contoso-motors" ]]; then
+    echo "Running curl command to install OpenVINO Toolkit Operator"
+    curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.31.0/install.sh | bash -s v0.31.0
+    sleep 10
+    echo "Installing operator via kubectl"
+    kubectl create -f https://operatorhub.io/install/ovms-operator.yaml
+fi
 
 exit 0

--- a/azure_jumpstart_ag/artifacts/kubernetes/K3s/installK3s.sh
+++ b/azure_jumpstart_ag/artifacts/kubernetes/K3s/installK3s.sh
@@ -320,7 +320,7 @@ storageContainerNameLower=$(echo $storageContainerName | tr '[:upper:]' '[:lower
 azcopy cp $log "https://$stagingStorageAccountName.blob.core.windows.net/$storageContainerNameLower/installK3s-$vmName.log" --check-length=false >/dev/null 2>&1
 
 # Add the if statement to check the scenario and run the curl command if scenario is contoso-motors
-if [[ "$scenario" == "contoso-motors" ]]; then
+if [[ "$scenario" == "contoso_motors" ]]; then
     echo "Running curl command to install OpenVINO Toolkit Operator"
     curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.31.0/install.sh | bash -s v0.31.0
     sleep 10

--- a/azure_jumpstart_ag/artifacts/kubernetes/K3s/installK3s.sh
+++ b/azure_jumpstart_ag/artifacts/kubernetes/K3s/installK3s.sh
@@ -320,12 +320,10 @@ storageContainerNameLower=$(echo $storageContainerName | tr '[:upper:]' '[:lower
 azcopy cp $log "https://$stagingStorageAccountName.blob.core.windows.net/$storageContainerNameLower/installK3s-$vmName.log" --check-length=false >/dev/null 2>&1
 
 # Add the if statement to check the scenario and run the curl command if scenario is contoso-motors
-if [[ "$scenario" == "contoso_motors" ]]; then
     echo "Running curl command to install OpenVINO Toolkit Operator"
     curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.31.0/install.sh | bash -s v0.31.0
     sleep 10
     echo "Installing operator via kubectl"
     kubectl create -f https://operatorhub.io/install/ovms-operator.yaml
-fi
 
 exit 0

--- a/azure_jumpstart_ag/contoso_motors/bicep/clientVm/clientVm.bicep
+++ b/azure_jumpstart_ag/contoso_motors/bicep/clientVm/clientVm.bicep
@@ -225,5 +225,17 @@ resource vmRoleAssignment_Storage 'Microsoft.Authorization/roleAssignments@2022-
   }
 }
 
+// Add role assignment for the VM: Owner
+resource vmRoleAssignment_Owner 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(vm.id, 'Microsoft.Authorization/roleAssignments', 'Owner')
+  scope: resourceGroup()
+  properties: {
+    principalId: vm.identity.principalId
+    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')
+    principalType: 'ServicePrincipal'
+  }
+}
+
+
 output adminUsername string = windowsAdminUsername
 output publicIP string = deployBastion == false ? concat(publicIpAddress.properties.ipAddress) : ''

--- a/azure_jumpstart_ag/contoso_motors/bicep/storage/storageAccount.bicep
+++ b/azure_jumpstart_ag/contoso_motors/bicep/storage/storageAccount.bicep
@@ -21,6 +21,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   properties: {
     supportsHttpsTrafficOnly: true
+    isHnsEnabled: true
   }
 }
 


### PR DESCRIPTION
This PR:

- removes the function to patch the AIO version used by the AZ CLI (since we're using the GA version)
- enabled HNS support on the aio storage account, since this is required
- uses curl to install the OpenVINO Toolkit Operator on each k3s cluster
- adds the client VM as an owner of the RG because it's required to create the schema registry.  Alternatively we could ensure the AZ CLI is using the SPN but the managed identity is likely preferrable